### PR TITLE
feat: add commit-msg

### DIFF
--- a/.github/hooks/commit-msg
+++ b/.github/hooks/commit-msg
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+
+"""The commit-msg Git hook tp check the commit message."""
+
+import sys
+from enum import Enum
+
+
+class BColors(str, Enum):
+    """A Enum for colors using ANSI escape sequences.
+    Reference:
+    - https://stackoverflow.com/questions/287871
+    """
+    OK       = '\u001b[32m'
+    INFO     = '\u001b[33m'
+    WARNING  = '\u001b[34m'
+    ERROR    = '\u001b[35m'
+    BOLD     = '\u001b[1m'
+    ENDC     = '\u001b[0m'
+
+
+class Notification(str, Enum):
+    """An Enum for notification levels.
+    """
+    OK      = "OK"
+    INFO    = "INFO"
+    WARNING = "WARNING"
+    ERROR   = "ERROR"
+
+
+def print_with_color(message: str, level: Notification) -> None:
+    """Print the message with a color for the corresponding level.
+    """
+    print(
+        BColors[level]
+        + BColors.BOLD
+        + f"{level}: [Policy]"
+        + message
+        + BColors.ENDC
+    )
+
+
+def check_tag(title):
+    _tags = ["chore", "docs", "style", "feat", "fix", "refactor", "test"]
+    for tag in _tags:
+        tag += ":"
+        if title.startswith(tag):
+            return True
+    return False
+
+
+def check_commit_msg_pattern():
+    """Check the format of the commit message.
+    The argument passed to the "commmit-msg" hook is the path to a 
+    temporary file that contains the commit message written by the
+    developer.
+    """
+    msg_temp = sys.argv[1]
+
+    with open(msg_temp, "r", encoding="utf-8") as f_msg:
+        lines = f_msg.readlines()
+
+    # Remove the comment lines in the commit message.
+    lines = [line for line in lines if not line.strip().startswith("#")]
+    has_warning = False
+    if len(lines) < 4:
+        message = "Commit message should have at least 4 lines."
+        print_with_color(message, Notification.ERROR)
+        sys.exit(1)
+
+    has_story_tag = False
+    if len(lines[0]) > 50:
+        has_warning = True
+        message = "Commit title max len must be less than 50 chars."
+        print_with_color(message, Notification.WARNING)
+    if check_tag(lines[0]):
+        has_story_tag = True
+    if lines[1].strip() != "":
+        has_warning = True
+        message = "Commit title and body should be seperated by empty line."
+        print_with_color(message, Notification.WARNING)
+
+    has_story_id = False
+    for line in lines[2:]:
+        if len(line) > 72:
+            has_warning = True
+            message = "Commit body should wrap at 72 chars."
+            print_with_color(message, Notification.WARNING)
+            sys.exit(1)
+        if "[#" in line:
+            has_story_id = True
+    if not has_story_id:
+        message = "Please add a issue ID in the commit message."
+        print_with_color(message, Notification.WARNING)
+        sys.exit(1)
+    if not has_story_tag:
+        message = "Please add a tag in the commit message."
+        print_with_color(message, Notification.WARNING)
+        sys.exit(1)
+    if not has_warning:
+        message = "Please follow the commit message pattern rules."
+        print_with_color(message, Notification.OK)
+
+
+if __name__ == "__main__":
+    check_commit_msg_pattern()
+    

--- a/.github/hooks/commit-msg
+++ b/.github/hooks/commit-msg
@@ -30,6 +30,9 @@ class Notification(str, Enum):
 
 def print_with_color(message: str, level: Notification) -> None:
     """Print the message with a color for the corresponding level.
+    Args:
+        message (str): message from the pattern
+        level (str): notification message level [OK, INFO, WARNING, ERROR]
     """
     print(
         BColors[level]
@@ -40,8 +43,14 @@ def print_with_color(message: str, level: Notification) -> None:
     )
 
 
-def check_tag(title):
-    _tags = ["chore", "docs", "style", "feat", "fix", "refactor", "test"]
+def check_tag(title: str)->bool:
+    """Checks the title of the commit message
+    Args:
+        title (str): first line of the commit message
+    Returns:
+        True or False
+    """
+    _tags = ["chore", "feat", "fix", "test"]
     for tag in _tags:
         tag += ":"
         if title.startswith(tag):
@@ -49,7 +58,7 @@ def check_tag(title):
     return False
 
 
-def check_commit_msg_pattern():
+def check_commit_msg_pattern()->None:
     """Check the format of the commit message.
     The argument passed to the "commmit-msg" hook is the path to a 
     temporary file that contains the commit message written by the

--- a/.github/hooks/commit-msg
+++ b/.github/hooks/commit-msg
@@ -43,7 +43,7 @@ def print_with_color(message: str, level: Notification) -> None:
     )
 
 
-def check_tag(title: str)->bool:
+def check_tag(title: str) -> bool:
     """Checks the title of the commit message
     Args:
         title (str): first line of the commit message
@@ -58,7 +58,7 @@ def check_tag(title: str)->bool:
     return False
 
 
-def check_commit_msg_pattern()->None:
+def check_commit_msg_pattern() -> None:
     """Check the format of the commit message.
     The argument passed to the "commmit-msg" hook is the path to a 
     temporary file that contains the commit message written by the

--- a/update.sh
+++ b/update.sh
@@ -16,8 +16,8 @@ git checkout main
 cd ..
 
 echo "update commit-msg"
-cp .github/hooks/commit-msg .git/hooks/commit-msg
-chmod +x .git/hooks/commit-msg
+cp .github/hooks/commit-msg ../.git/hooks/commit-msg
+chmod +x ../.git/hooks/commit-msg
 
 echo "remove old version of pylintrc and .pre-commit-config.yaml"
 rm -rf .pylintrc

--- a/update.sh
+++ b/update.sh
@@ -15,6 +15,10 @@ git pull origin main
 git checkout main
 cd ..
 
+echo "update commit-msg"
+cp .github/hooks/commit-msg .git/hooks/commit-msg
+chmod +x .git/hooks/commit-msg
+
 echo "remove old version of pylintrc and .pre-commit-config.yaml"
 rm -rf .pylintrc
 rm -rf .pre-commit-config.yaml


### PR DESCRIPTION
This is rule requires at least 4 lines of message
Title and body should be seperated by empty line
[#OK] each commet should have tags.

I checked it only with `commit-msg` branch because I could not use `update.sh` because it requires me to be in `main` branch. 